### PR TITLE
Add shared sensor unit test target

### DIFF
--- a/.github/workflows/camera-sensor-tests.yml
+++ b/.github/workflows/camera-sensor-tests.yml
@@ -1,4 +1,4 @@
-name: Camera Sensor Tests
+name: Sensor Unit Tests
 
 on:
   push:
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  camera-unit-tests:
-    name: Camera Unit Tests (ubuntu-latest)
+  sensor-unit-tests:
+    name: Sensor Unit Tests (ubuntu-latest)
     runs-on: ubuntu-latest
 
     steps:
@@ -32,15 +32,10 @@ jobs:
             -DHAKO_BUILD_CAMERA_SMOKE_TESTS=OFF \
             -DUSE_VIEWER=OFF
 
-      - name: Build camera unit tests
+      - name: Build sensor unit tests
         run: |
-          cmake --build src/cmake-build -j4 --target \
-            camera_config_loader_test \
-            camera_pdu_converter_test \
-            depth_encoding_test
+          cmake --build src/cmake-build -j4 --target sensor_unit_tests
 
-      - name: Run camera unit tests
+      - name: Run sensor unit tests
         run: |
-          ./src/cmake-build/sensors/camera_config_loader_test
-          ./src/cmake-build/sensors/camera_pdu_converter_test
-          ./src/cmake-build/sensors/depth_encoding_test
+          cmake --build src/cmake-build --target run_sensor_unit_tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+This directory contains small, user-facing examples for trying individual Hakoniwa MuJoCo features without running the full robot demos.
+
+## Sensor Examples
+
+Sensor examples live under:
+
+```text
+examples/sensors/
+```
+
+Available examples:
+
+- [Ultrasonic Sensor Example](sensors/ultrasonic/README.md)
+  - minimal MuJoCo ultrasonic range sensor
+  - interactive keyboard movement
+  - measured ray visualization in the MuJoCo viewer
+  - `sensor_msgs/Range` PDU conversion path
+
+These examples are intended to complement the larger TurtleBot3 and forklift demos described in the top-level README.

--- a/examples/sensors/README.md
+++ b/examples/sensors/README.md
@@ -1,0 +1,26 @@
+# Sensor Examples
+
+This directory contains small examples for Hakoniwa MuJoCo sensor components.
+
+## Ultrasonic
+
+See:
+
+```text
+examples/sensors/ultrasonic/README.md
+```
+
+The ultrasonic example demonstrates:
+
+- loading a minimal MuJoCo model
+- binding a range sensor to a MuJoCo `site`
+- moving the robot body interactively with `i/k/j/l`
+- measuring range with `s`
+- visualizing the measured ray in the MuJoCo viewer
+- converting the internal ultrasonic frame to `sensor_msgs/Range`
+
+Run from the repository root:
+
+```bash
+./src/cmake-build/examples/sensors/ultrasonic/ultrasonic-example
+```

--- a/examples/sensors/ultrasonic/README.md
+++ b/examples/sensors/ultrasonic/README.md
@@ -1,16 +1,19 @@
 # Ultrasonic Sensor Example
 
-This example demonstrates the Hakoniwa MuJoCo ultrasonic sensor with a minimal MJCF model.
+This example demonstrates a Hakoniwa ultrasonic range sensor running on MuJoCo.
 
-The purpose of this example is to manually verify that the ultrasonic sensor can:
+It is intended as a small, user-facing example for understanding how a Hakoniwa sensor is modeled, configured, measured, visualized, and converted to a ROS-compatible PDU data type.
 
-- load a MuJoCo model
-- resolve a sensor site
-- move the robot body with keyboard commands
-- measure distance from the sensor site
-- show how the measured range changes as the robot moves
+The example shows how to:
 
-This is an interactive example, not a strict automated test.
+- load a minimal MuJoCo model
+- bind an ultrasonic sensor to a MuJoCo `site`
+- move the robot body interactively
+- measure range from the sensor site
+- visualize the measured ray in the MuJoCo viewer
+- convert the internal ultrasonic frame to `sensor_msgs/Range`
+
+This is an interactive example. Automated checks for the same basic behavior are provided by the sensor unit tests.
 
 ## Files
 
@@ -24,11 +27,16 @@ models/sensors/ultrasonic/
 
 config/sensors/ultrasonic/
   lego-spike-distance-sensor.json
-````
+
+tests/sensors/ultrasonic/unit/
+  ultrasonic_config_loader_test.cpp
+  ultrasonic_range_pdu_converter_test.cpp
+  ultrasonic_measurement_test.cpp
+```
 
 ## Model
 
-The example uses the following MJCF model:
+The example uses this MJCF model:
 
 ```text
 models/sensors/ultrasonic/ultrasonic-sensor-test.xml
@@ -36,24 +44,56 @@ models/sensors/ultrasonic/ultrasonic-sensor-test.xml
 
 The model contains:
 
-* a movable base body named `base_footprint`
-* a sensor site named `front_ultrasonic_site`
-* a front wall
-* a diagonal obstacle for cone-ray behavior checks
+- a movable robot body named `base_footprint`
+- a free joint named `base_freejoint`
+- a sensor site named `front_ultrasonic_site`
+- a front wall
+- a diagonal obstacle
 
-The ultrasonic sensor uses the local `+X` axis of the source site as the measurement direction.
+The ultrasonic sensor uses the local `+X` axis of the source site as its measurement direction.
+
+In other words, the ray starts at `front_ultrasonic_site` and points along the site's local forward direction.
 
 ## Sensor Config
 
-The example uses the following ultrasonic sensor profile:
+The example uses this sensor profile:
 
 ```text
 config/sensors/ultrasonic/lego-spike-distance-sensor.json
 ```
 
-This profile represents a simple LEGO SPIKE-like distance sensor.
+The profile currently represents a simple LEGO SPIKE-like distance sensor profile for Hakoniwa testing.
 
-## Expected Initial Distance
+Important fields:
+
+```json
+{
+  "DetectionDistance": {
+    "Min": 0.05,
+    "Max": 2.0
+  },
+  "DistanceAccuracy": [
+    {
+      "StdDev": 0.0,
+      "Precision": 0.0,
+      "NoiseDistribution": "none"
+    }
+  ],
+  "Cone": {
+    "Horizontal": 0.0,
+    "Vertical": 0.0,
+    "RayCount": 1
+  },
+  "RadiationType": "ultrasound",
+  "RuntimeBinding": {
+    "source_site": "front_ultrasonic_site"
+  }
+}
+```
+
+For this example, noise is disabled and `RayCount` is `1`, so the measurement is deterministic and easy to verify.
+
+## Expected Distances
 
 The front wall is located at `x = 1.0`.
 
@@ -63,19 +103,61 @@ The wall half-size along the X axis is `0.02`, so the front surface of the wall 
 x = 1.0 - 0.02 = 0.98
 ```
 
-The sensor site is located at:
+The sensor site is initially located at:
 
 ```text
 x = 0.12
 ```
 
-Therefore, the expected initial surface distance is approximately:
+Therefore, the expected initial surface distance is:
 
 ```text
 0.98 - 0.12 = 0.86 m
 ```
 
-Small differences are acceptable depending on raycast behavior, geometry resolution, and future sensor runtime policies.
+When the robot moves forward by `0.05 m`, the expected range becomes:
+
+```text
+0.86 - 0.05 = 0.81 m
+```
+
+The unit test also verifies a diagonal obstacle hit and a no-hit case.
+
+## Build
+
+From the repository root:
+
+```bash
+./build.bash
+```
+
+Or, if CMake has already been configured:
+
+```bash
+cmake --build src/cmake-build
+```
+
+The example target is:
+
+```text
+ultrasonic-example
+```
+
+## Run
+
+From the repository root:
+
+```bash
+./src/cmake-build/examples/sensors/ultrasonic/ultrasonic-example
+```
+
+You can also pass a model path and config path explicitly:
+
+```bash
+./src/cmake-build/examples/sensors/ultrasonic/ultrasonic-example \
+  models/sensors/ultrasonic/ultrasonic-sensor-test.xml \
+  config/sensors/ultrasonic/lego-spike-distance-sensor.json
+```
 
 ## Controls
 
@@ -87,17 +169,39 @@ k : move backward (-X)
 j : move left     (+Y)
 l : move right    (-Y)
 s : sense and print ultrasonic range
+h : help
 q : quit
 ```
 
-The initial implementation uses translation only.
-Yaw rotation is intentionally omitted to keep the first example focused on position and distance behavior.
+Moving with `i`, `k`, `j`, or `l` updates the robot position and refreshes the ultrasonic measurement.
+
+Pressing `s` explicitly measures the current range and prints the latest result.
+
+## Viewer
+
+The MuJoCo viewer displays the model and the latest measured ray.
+
+After the first measurement:
+
+- green ray means hit
+- red ray means no-hit
+
+The ray is drawn from the sensor site to the measured range endpoint.
+
+Mathematically, the endpoint is:
+
+```text
+to = site_position + world_forward * range
+```
+
+where `world_forward` is the source site's local `+X` direction transformed into world coordinates.
+
+This debug visualization is useful for ultrasonic sensors and can also be reused for 2D LiDAR ray visualization.
 
 ## Example Session
 
 ```text
 Hakoniwa Ultrasonic Sensor Example
-
 model : models/sensors/ultrasonic/ultrasonic-sensor-test.xml
 config: config/sensors/ultrasonic/lego-spike-distance-sensor.json
 site  : front_ultrasonic_site
@@ -107,88 +211,117 @@ Controls:
   k : move backward (-X)
   j : move left     (+Y)
   l : move right    (-Y)
-  s : sense
+  s : sense and print ultrasonic range
+  h : help
   q : quit
 
+base_pos=(0.000, 0.000, 0.100)
 > s
-range: 0.860 m
-
+range=0.860 m, status=OK, variance=0.000e+00
 > i
+range=0.810 m, status=OK, variance=0.000e+00
 moved: x += 0.050, base_pos=(0.050, 0.000, 0.100)
-
-> s
-range: 0.810 m
-
-> k
-moved: x -= 0.050, base_pos=(0.000, 0.000, 0.100)
-
 > j
-moved: y += 0.050, base_pos=(0.000, 0.050, 0.100)
-
-> s
-range: 0.862 m
+range=0.810 m, status=OK, variance=0.000e+00
+moved: y += 0.050, base_pos=(0.050, 0.050, 0.100)
 ```
 
-## Build
+## PDU Mapping
 
-From the repository root:
+The ultrasonic sensor keeps an internal frame with simulation-friendly diagnostic data:
 
-```bash
-./build.bash
+```text
+UltrasonicFrame
+  frame_id
+  range
+  variance
+  status
 ```
 
-Or build directly with CMake:
+For external communication, it can be converted to the ROS-compatible Hakoniwa PDU type:
 
-```bash
-cmake --build src/cmake-build
+```text
+sensor_msgs/Range
+  std_msgs/Header header
+  uint8 radiation_type
+  float32 field_of_view
+  float32 min_range
+  float32 max_range
+  float32 range
 ```
 
-## Run
+Mapping:
+
+```text
+UltrasonicConfig.frame_id              -> Range.header.frame_id
+UltrasonicConfig.radiation_type        -> Range.radiation_type
+UltrasonicConfig.cone.horizontal       -> Range.field_of_view
+UltrasonicConfig.detection_distance.min -> Range.min_range
+UltrasonicConfig.detection_distance.max -> Range.max_range
+UltrasonicFrame.range                  -> Range.range
+```
+
+`variance` and `status` are internal diagnostic fields and are not part of ROS `sensor_msgs/Range`.
+
+## Tests
+
+Sensor unit tests can be built with:
 
 ```bash
-./src/cmake-build/examples/sensors/ultrasonic/ultrasonic-example
+cmake -S src -B src/cmake-build \
+  -DHAKO_USE_THIRDPARTY_HAKONIWA=ON \
+  -DHAKO_BUILD_SENSOR_TESTS=ON \
+  -DHAKO_BUILD_CAMERA_SMOKE_TESTS=OFF \
+  -DUSE_VIEWER=OFF
+
+cmake --build src/cmake-build --target sensor_unit_tests
+```
+
+Run all sensor unit tests:
+
+```bash
+cmake --build src/cmake-build --target run_sensor_unit_tests
+```
+
+Ultrasonic-specific tests are grouped under:
+
+```text
+ultrasonic_unit_tests
+```
+
+They verify:
+
+- config loading
+- `sensor_msgs/Range` PDU conversion
+- deterministic measurement values with noise disabled
+
+The deterministic measurement test checks:
+
+```text
+initial front wall range        = 0.86 m
+front wall range after x move   = 0.81 m
+diagonal obstacle range         = 0.18 m
+no-hit range                    = 2.00 m with NO_HIT status
 ```
 
 ## Current Scope
 
-This example is intentionally minimal.
-
 Included:
 
-* MuJoCo model loading
-* ultrasonic sensor config loading
-* source site lookup
-* keyboard-based base movement
-* manual sensing with `s`
-* range output to standard output
+- MuJoCo model loading
+- ultrasonic sensor config loading
+- source site lookup
+- keyboard-based base movement
+- deterministic range measurement
+- MuJoCo viewer ray overlay
+- `sensor_msgs/Range` PDU conversion
+- automated unit tests for config, PDU conversion, and measurement values
 
-Not included in the first version:
+Not included yet:
 
-* Hakoniwa PDU publish
-* viewer integration
-* automatic assertions
-* CI execution
-* yaw rotation
-* multi-sensor setup
+- live Hakoniwa endpoint publish from the example
+- yaw rotation controls
+- multi-sensor setup
+- full 2D LiDAR ray overlay
 
-Those features can be added later after the basic sensor behavior is stable.
-
-## Relationship to Tests
-
-This example is a manual usage example.
-
-After the behavior is stabilized, the same logic can be promoted into automated smoke tests under:
-
-```text
-tests/sensors/ultrasonic/
-```
-
-A future smoke test should verify at least:
-
-* model load succeeds
-* `front_ultrasonic_site` exists
-* initial range is approximately `0.86 m`
-* moving forward decreases the measured range
-* moving backward increases the measured range
-* self geometry is not detected as the nearest hit
-
+These can be added incrementally now that the sensor, viewer, PDU, example, and test paths are connected.

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -85,6 +85,10 @@ if(HAKO_BUILD_SENSOR_TESTS)
         ultrasonic_range_pdu_converter_test
         ${PROJECT_ROOT_DIR}/tests/sensors/ultrasonic/unit/ultrasonic_range_pdu_converter_test.cpp
     )
+    hako_add_sensor_test(
+        ultrasonic_measurement_test
+        ${PROJECT_ROOT_DIR}/tests/sensors/ultrasonic/unit/ultrasonic_measurement_test.cpp
+    )
 
     add_custom_target(
         camera_unit_tests
@@ -98,6 +102,7 @@ if(HAKO_BUILD_SENSOR_TESTS)
         DEPENDS
             ultrasonic_config_loader_test
             ultrasonic_range_pdu_converter_test
+            ultrasonic_measurement_test
     )
     add_custom_target(
         sensor_unit_tests
@@ -112,6 +117,7 @@ if(HAKO_BUILD_SENSOR_TESTS)
         COMMAND $<TARGET_FILE:depth_encoding_test>
         COMMAND $<TARGET_FILE:ultrasonic_config_loader_test>
         COMMAND $<TARGET_FILE:ultrasonic_range_pdu_converter_test>
+        COMMAND $<TARGET_FILE:ultrasonic_measurement_test>
         DEPENDS sensor_unit_tests
         WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
         USES_TERMINAL

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(msensors
 )
 target_compile_definitions(msensors PRIVATE USE_VIEWER=$<BOOL:${USE_VIEWER}>)
 
-function(hako_add_camera_test target_name source_file)
+function(hako_add_sensor_test target_name source_file)
     add_executable(${target_name} ${source_file})
     target_include_directories(${target_name}
         PRIVATE ${PROJECT_ROOT_DIR}
@@ -65,17 +65,25 @@ function(hako_add_camera_test target_name source_file)
 endfunction()
 
 if(HAKO_BUILD_SENSOR_TESTS)
-    hako_add_camera_test(
+    hako_add_sensor_test(
         camera_config_loader_test
         ${PROJECT_ROOT_DIR}/tests/sensors/camera/unit/camera_config_loader_test.cpp
     )
-    hako_add_camera_test(
+    hako_add_sensor_test(
         camera_pdu_converter_test
         ${PROJECT_ROOT_DIR}/tests/sensors/camera/unit/camera_pdu_converter_test.cpp
     )
-    hako_add_camera_test(
+    hako_add_sensor_test(
         depth_encoding_test
         ${PROJECT_ROOT_DIR}/tests/sensors/camera/unit/depth_encoding_test.cpp
+    )
+    hako_add_sensor_test(
+        ultrasonic_config_loader_test
+        ${PROJECT_ROOT_DIR}/tests/sensors/ultrasonic/unit/ultrasonic_config_loader_test.cpp
+    )
+    hako_add_sensor_test(
+        ultrasonic_range_pdu_converter_test
+        ${PROJECT_ROOT_DIR}/tests/sensors/ultrasonic/unit/ultrasonic_range_pdu_converter_test.cpp
     )
 
     add_custom_target(
@@ -84,6 +92,28 @@ if(HAKO_BUILD_SENSOR_TESTS)
             camera_config_loader_test
             camera_pdu_converter_test
             depth_encoding_test
+    )
+    add_custom_target(
+        ultrasonic_unit_tests
+        DEPENDS
+            ultrasonic_config_loader_test
+            ultrasonic_range_pdu_converter_test
+    )
+    add_custom_target(
+        sensor_unit_tests
+        DEPENDS
+            camera_unit_tests
+            ultrasonic_unit_tests
+    )
+    add_custom_target(
+        run_sensor_unit_tests
+        COMMAND $<TARGET_FILE:camera_config_loader_test>
+        COMMAND $<TARGET_FILE:camera_pdu_converter_test>
+        COMMAND $<TARGET_FILE:depth_encoding_test>
+        COMMAND $<TARGET_FILE:ultrasonic_config_loader_test>
+        COMMAND $<TARGET_FILE:ultrasonic_range_pdu_converter_test>
+        DEPENDS sensor_unit_tests
+        USES_TERMINAL
     )
     add_custom_target(
         run_camera_unit_tests
@@ -96,7 +126,7 @@ if(HAKO_BUILD_SENSOR_TESTS)
 endif()
 
 if(HAKO_BUILD_CAMERA_SMOKE_TESTS)
-    hako_add_camera_test(
+    hako_add_sensor_test(
         depth_render_smoke_test
         ${PROJECT_ROOT_DIR}/tests/sensors/camera/smoke/depth_render_smoke_test.cpp
     )

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -113,6 +113,7 @@ if(HAKO_BUILD_SENSOR_TESTS)
         COMMAND $<TARGET_FILE:ultrasonic_config_loader_test>
         COMMAND $<TARGET_FILE:ultrasonic_range_pdu_converter_test>
         DEPENDS sensor_unit_tests
+        WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
         USES_TERMINAL
     )
     add_custom_target(
@@ -121,6 +122,7 @@ if(HAKO_BUILD_SENSOR_TESTS)
         COMMAND $<TARGET_FILE:camera_pdu_converter_test>
         COMMAND $<TARGET_FILE:depth_encoding_test>
         DEPENDS camera_unit_tests
+        WORKING_DIRECTORY ${PROJECT_ROOT_DIR}
         USES_TERMINAL
     )
 endif()

--- a/tests/sensors/camera/support/camera_test_utils.hpp
+++ b/tests/sensors/camera/support/camera_test_utils.hpp
@@ -1,39 +1,19 @@
 #pragma once
 
-#include <cmath>
+#include "tests/sensors/support/sensor_test_utils.hpp"
+
 #include <cstdint>
-#include <cstdlib>
-#include <filesystem>
-#include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
-#include "builtin_interfaces/pdu_cpptype_Time.hpp"
 #include "sensors/camera/camera_sensor.hpp"
 
 namespace hako::robots::sensor::camera::test
 {
-    [[noreturn]] inline void FailExpectation(const char* file, int line, const std::string& message)
-    {
-        std::cerr << file << ":" << line << ": " << message << std::endl;
-        std::abort();
-    }
-
-    inline bool NearlyEqual(double lhs, double rhs, double epsilon = 1.0e-6)
-    {
-        return std::abs(lhs - rhs) <= epsilon;
-    }
-
-    inline bool NearlyEqual(float lhs, float rhs, float epsilon = 1.0e-6F)
-    {
-        return std::abs(lhs - rhs) <= epsilon;
-    }
-
-    inline std::filesystem::path RepoRoot()
-    {
-        return std::filesystem::current_path();
-    }
+    using ::hako::robots::sensor::test::FailExpectation;
+    using ::hako::robots::sensor::test::NearlyEqual;
+    using ::hako::robots::sensor::test::RepoRoot;
+    using ::hako::robots::sensor::test::ExpectHakoTime;
 
     inline hako::robots::sensor::camera::ImageFrame MakeImageFrame(
         int width,
@@ -41,7 +21,7 @@ namespace hako::robots::sensor::camera::test
         const std::string& format,
         const std::string& frame_id,
         double timestamp,
-        std::vector<uint8_t> data)
+        std::vector<std::uint8_t> data)
     {
         hako::robots::sensor::camera::ImageFrame frame {};
         frame.width = width;
@@ -75,31 +55,4 @@ namespace hako::robots::sensor::camera::test
         frame.data = std::move(data);
         return frame;
     }
-
-    inline void ExpectHakoTime(
-        const HakoCpp_Time& actual,
-        int expected_sec,
-        uint32_t expected_nanosec,
-        const char* file,
-        int line)
-    {
-        if (actual.sec != expected_sec || actual.nanosec != expected_nanosec) {
-            std::ostringstream oss;
-            oss << "unexpected HakoCpp_Time: actual=(" << actual.sec << ", " << actual.nanosec
-                << "), expected=(" << expected_sec << ", " << expected_nanosec << ")";
-            FailExpectation(file, line, oss.str());
-        }
-    }
 }
-
-#define HAKO_TEST_EXPECT(cond, msg) \
-    do { \
-        if (!(cond)) { \
-            ::hako::robots::sensor::camera::test::FailExpectation(__FILE__, __LINE__, (msg)); \
-        } \
-    } while (false)
-
-#define HAKO_TEST_EXPECT_TIME(actual, sec, nanosec) \
-    do { \
-        ::hako::robots::sensor::camera::test::ExpectHakoTime((actual), (sec), (nanosec), __FILE__, __LINE__); \
-    } while (false)

--- a/tests/sensors/support/sensor_test_utils.hpp
+++ b/tests/sensors/support/sensor_test_utils.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "builtin_interfaces/pdu_cpptype_Time.hpp"
+
+namespace hako::robots::sensor::test
+{
+    inline void FailExpectation(const char* file, int line, const std::string& message)
+    {
+        std::ostringstream oss;
+        oss << file << ":" << line << ": " << message;
+        throw std::runtime_error(oss.str());
+    }
+
+    inline bool NearlyEqual(double lhs, double rhs, double epsilon = 1.0e-6)
+    {
+        return std::abs(lhs - rhs) <= epsilon;
+    }
+
+    inline bool NearlyEqual(float lhs, float rhs, float epsilon = 1.0e-6F)
+    {
+        return std::abs(lhs - rhs) <= epsilon;
+    }
+
+    inline std::filesystem::path RepoRoot()
+    {
+        return std::filesystem::current_path();
+    }
+
+    inline void ExpectHakoTime(
+        const HakoCpp_Time& actual,
+        int expected_sec,
+        std::uint32_t expected_nanosec,
+        const char* file,
+        int line)
+    {
+        if (actual.sec != expected_sec || actual.nanosec != expected_nanosec) {
+            std::ostringstream oss;
+            oss << "unexpected HakoCpp_Time: actual=(" << actual.sec << ", " << actual.nanosec
+                << "), expected=(" << expected_sec << ", " << expected_nanosec << ")";
+            FailExpectation(file, line, oss.str());
+        }
+    }
+}
+
+#define HAKO_TEST_EXPECT(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            ::hako::robots::sensor::test::FailExpectation(__FILE__, __LINE__, (msg)); \
+        } \
+    } while (false)
+
+#define HAKO_TEST_EXPECT_TIME(actual, sec, nanosec) \
+    do { \
+        ::hako::robots::sensor::test::ExpectHakoTime((actual), (sec), (nanosec), __FILE__, __LINE__); \
+    } while (false)

--- a/tests/sensors/ultrasonic/unit/ultrasonic_config_loader_test.cpp
+++ b/tests/sensors/ultrasonic/unit/ultrasonic_config_loader_test.cpp
@@ -1,0 +1,100 @@
+#include "physics.hpp"
+#include "sensors/ultrasonic/ultrasonic_sensor.hpp"
+#include "tests/sensors/support/sensor_test_utils.hpp"
+
+#include <mujoco/mujoco.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+using hako::robots::sensor::test::NearlyEqual;
+using hako::robots::sensor::test::RepoRoot;
+using hako::robots::sensor::ultrasonic::RangeRadiationType;
+
+class TestWorld final : public hako::robots::physics::IWorld {
+public:
+    void loadModel(const std::string& model_file) override
+    {
+        char error[1024] = {0};
+        model = mj_loadXML(model_file.c_str(), nullptr, error, sizeof(error));
+        if (model == nullptr) {
+            throw std::runtime_error(
+                std::string("failed to load MuJoCo model: ") + model_file + "\n" + error);
+        }
+
+        data = mj_makeData(model);
+        if (data == nullptr) {
+            throw std::runtime_error("failed to allocate MuJoCo data");
+        }
+
+        mj_forward(model, data);
+    }
+
+    void advanceTimeStep() override
+    {
+        if (model != nullptr && data != nullptr) {
+            mj_step(model, data);
+        }
+    }
+
+    std::shared_ptr<hako::robots::physics::IRigidBody>
+    getRigidBody(const std::string& /*model_name*/) override
+    {
+        return nullptr;
+    }
+
+    std::shared_ptr<hako::robots::actuator::ITorqueActuator>
+    getTorqueActuator(const std::string& /*name*/) override
+    {
+        return nullptr;
+    }
+};
+
+void TestLegoSpikeDistanceSensorConfig()
+{
+    auto world = std::make_shared<TestWorld>();
+    world->loadModel((RepoRoot() / "models/sensors/ultrasonic/ultrasonic-sensor-test.xml").string());
+
+    hako::robots::sensor::ultrasonic::UltrasonicSensor sensor(
+        world,
+        "front_ultrasonic_site",
+        "base_footprint");
+
+    const auto path = (RepoRoot() / "config/sensors/ultrasonic/lego-spike-distance-sensor.json").string();
+    const bool ok = sensor.LoadConfig(path);
+    HAKO_TEST_EXPECT(ok, "lego-spike-distance-sensor.json should load");
+
+    const auto& config = sensor.GetConfig();
+    HAKO_TEST_EXPECT(config.frame_id == "spike_distance_sensor_link", "unexpected frame_id");
+    HAKO_TEST_EXPECT(config.radiation_type == RangeRadiationType::ULTRASOUND, "unexpected radiation_type");
+    HAKO_TEST_EXPECT(NearlyEqual(config.detection_distance.min, 0.05), "unexpected min range");
+    HAKO_TEST_EXPECT(NearlyEqual(config.detection_distance.max, 2.0), "unexpected max range");
+    HAKO_TEST_EXPECT(config.distance_accuracy.size() == 1U, "unexpected distance accuracy count");
+    HAKO_TEST_EXPECT(NearlyEqual(config.distance_accuracy[0].stddev, 0.0), "unexpected stddev");
+    HAKO_TEST_EXPECT(NearlyEqual(config.distance_accuracy[0].precision, 0.0), "unexpected precision");
+    HAKO_TEST_EXPECT(config.distance_accuracy[0].noise_distribution == "none", "unexpected noise distribution");
+    HAKO_TEST_EXPECT(NearlyEqual(config.cone.horizontal, 0.0), "unexpected horizontal FOV");
+    HAKO_TEST_EXPECT(NearlyEqual(config.cone.vertical, 0.0), "unexpected vertical FOV");
+    HAKO_TEST_EXPECT(config.cone.ray_count == 1, "unexpected ray count");
+    HAKO_TEST_EXPECT(NearlyEqual(config.update_rate, 100.0), "unexpected update rate");
+    HAKO_TEST_EXPECT(config.runtime_binding.source_site == "front_ultrasonic_site", "unexpected source site");
+}
+}
+
+int main()
+{
+    try {
+        TestLegoSpikeDistanceSensorConfig();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "ultrasonic_config_loader_test passed" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/tests/sensors/ultrasonic/unit/ultrasonic_measurement_test.cpp
+++ b/tests/sensors/ultrasonic/unit/ultrasonic_measurement_test.cpp
@@ -1,0 +1,146 @@
+#include "physics.hpp"
+#include "sensors/ultrasonic/ultrasonic_sensor.hpp"
+#include "tests/sensors/support/sensor_test_utils.hpp"
+
+#include <mujoco/mujoco.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+using hako::robots::sensor::test::NearlyEqual;
+using hako::robots::sensor::test::RepoRoot;
+using hako::robots::sensor::ultrasonic::UltrasonicFrame;
+using hako::robots::sensor::ultrasonic::UltrasonicStatus;
+
+constexpr double kEpsilon = 1.0e-6;
+
+class TestWorld final : public hako::robots::physics::IWorld {
+public:
+    void loadModel(const std::string& model_file) override
+    {
+        char error[1024] = {0};
+        model = mj_loadXML(model_file.c_str(), nullptr, error, sizeof(error));
+        if (model == nullptr) {
+            throw std::runtime_error(
+                std::string("failed to load MuJoCo model: ") + model_file + "\n" + error);
+        }
+
+        data = mj_makeData(model);
+        if (data == nullptr) {
+            throw std::runtime_error("failed to allocate MuJoCo data");
+        }
+
+        mj_forward(model, data);
+    }
+
+    void advanceTimeStep() override
+    {
+        if (model != nullptr && data != nullptr) {
+            mj_step(model, data);
+        }
+    }
+
+    std::shared_ptr<hako::robots::physics::IRigidBody>
+    getRigidBody(const std::string& /*model_name*/) override
+    {
+        return nullptr;
+    }
+
+    std::shared_ptr<hako::robots::actuator::ITorqueActuator>
+    getTorqueActuator(const std::string& /*name*/) override
+    {
+        return nullptr;
+    }
+};
+
+int FindBaseFreejointQposAddr(const mjModel* model)
+{
+    const int joint_id = mj_name2id(model, mjOBJ_JOINT, "base_freejoint");
+    HAKO_TEST_EXPECT(joint_id >= 0, "base_freejoint should exist");
+    HAKO_TEST_EXPECT(model->jnt_type[joint_id] == mjJNT_FREE, "base_freejoint should be a freejoint");
+    return model->jnt_qposadr[joint_id];
+}
+
+void SetBasePosition(mjModel* model, mjData* data, int qpos_addr, double x, double y, double z)
+{
+    data->qpos[qpos_addr + 0] = x;
+    data->qpos[qpos_addr + 1] = y;
+    data->qpos[qpos_addr + 2] = z;
+
+    // Keep the freejoint orientation fixed.
+    data->qpos[qpos_addr + 3] = 1.0;
+    data->qpos[qpos_addr + 4] = 0.0;
+    data->qpos[qpos_addr + 5] = 0.0;
+    data->qpos[qpos_addr + 6] = 0.0;
+
+    mj_forward(model, data);
+}
+
+UltrasonicFrame Measure(hako::robots::sensor::ultrasonic::UltrasonicSensor& sensor)
+{
+    UltrasonicFrame frame {};
+    sensor.Measure(frame);
+    return frame;
+}
+
+void ExpectRangeOk(const UltrasonicFrame& frame, double expected_range, const char* label)
+{
+    HAKO_TEST_EXPECT(frame.status == UltrasonicStatus::OK, std::string(label) + ": expected OK status");
+    HAKO_TEST_EXPECT(NearlyEqual(frame.range, expected_range, kEpsilon), std::string(label) + ": unexpected range");
+    HAKO_TEST_EXPECT(NearlyEqual(frame.variance, 0.0, kEpsilon), std::string(label) + ": unexpected variance");
+}
+
+void TestDeterministicUltrasonicMeasurement()
+{
+    auto world = std::make_shared<TestWorld>();
+    world->loadModel((RepoRoot() / "models/sensors/ultrasonic/ultrasonic-sensor-test.xml").string());
+
+    auto* model = world->getModel();
+    auto* data = world->getData();
+    HAKO_TEST_EXPECT(model != nullptr, "model should not be null");
+    HAKO_TEST_EXPECT(data != nullptr, "data should not be null");
+
+    const int qpos_addr = FindBaseFreejointQposAddr(model);
+
+    hako::robots::sensor::ultrasonic::UltrasonicSensor sensor(
+        world,
+        "front_ultrasonic_site",
+        "base_footprint");
+
+    const auto config_path = (RepoRoot() / "config/sensors/ultrasonic/lego-spike-distance-sensor.json").string();
+    HAKO_TEST_EXPECT(sensor.LoadConfig(config_path), "ultrasonic config should load");
+
+    SetBasePosition(model, data, qpos_addr, 0.0, 0.0, 0.1);
+    ExpectRangeOk(Measure(sensor), 0.86, "initial front wall range");
+
+    SetBasePosition(model, data, qpos_addr, 0.05, 0.0, 0.1);
+    ExpectRangeOk(Measure(sensor), 0.81, "front wall range after x move");
+
+    SetBasePosition(model, data, qpos_addr, 0.45, 0.30, 0.1);
+    ExpectRangeOk(Measure(sensor), 0.18, "diagonal obstacle range");
+
+    SetBasePosition(model, data, qpos_addr, 0.45, 0.55, 0.1);
+    const auto no_hit_frame = Measure(sensor);
+    HAKO_TEST_EXPECT(no_hit_frame.status == UltrasonicStatus::NO_HIT, "expected NO_HIT status");
+    HAKO_TEST_EXPECT(NearlyEqual(no_hit_frame.range, 2.0, kEpsilon), "unexpected no-hit range");
+    HAKO_TEST_EXPECT(NearlyEqual(no_hit_frame.variance, 0.0, kEpsilon), "unexpected no-hit variance");
+}
+}
+
+int main()
+{
+    try {
+        TestDeterministicUltrasonicMeasurement();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "ultrasonic_measurement_test passed" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/tests/sensors/ultrasonic/unit/ultrasonic_range_pdu_converter_test.cpp
+++ b/tests/sensors/ultrasonic/unit/ultrasonic_range_pdu_converter_test.cpp
@@ -1,0 +1,77 @@
+#include "sensors/ultrasonic/ultrasonic_sensor.hpp"
+#include "tests/sensors/support/sensor_test_utils.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+
+namespace
+{
+using hako::robots::sensor::test::NearlyEqual;
+using hako::robots::sensor::ultrasonic::IUltrasonicSensor;
+using hako::robots::sensor::ultrasonic::RangeRadiationType;
+using hako::robots::sensor::ultrasonic::UltrasonicConfig;
+using hako::robots::sensor::ultrasonic::UltrasonicFrame;
+using hako::robots::sensor::ultrasonic::UltrasonicStatus;
+
+void TestRangePduConversion()
+{
+    UltrasonicConfig config {};
+    config.frame_id = "front_ultrasonic";
+    config.radiation_type = RangeRadiationType::ULTRASOUND;
+    config.cone.horizontal = 1.221730476;
+    config.detection_distance.min = 0.05;
+    config.detection_distance.max = 2.0;
+
+    UltrasonicFrame frame {};
+    frame.frame_id = "front_ultrasonic";
+    frame.range = 0.86;
+    frame.variance = 0.25;
+    frame.status = UltrasonicStatus::OK;
+
+    const HakoCpp_Range pdu = IUltrasonicSensor::ToRangePdu(config, frame);
+
+    HAKO_TEST_EXPECT(pdu.header.frame_id == "front_ultrasonic", "unexpected frame_id");
+    HAKO_TEST_EXPECT(pdu.radiation_type == 0, "unexpected radiation type");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.field_of_view, static_cast<float>(config.cone.horizontal)), "unexpected field_of_view");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.min_range, 0.05F), "unexpected min_range");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.max_range, 2.0F), "unexpected max_range");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.range, 0.86F), "unexpected range");
+}
+
+void TestInfraredRadiationTypeConversion()
+{
+    UltrasonicConfig config {};
+    config.frame_id = "ir_range";
+    config.radiation_type = RangeRadiationType::INFRARED;
+    config.cone.horizontal = 0.5;
+    config.detection_distance.min = 0.1;
+    config.detection_distance.max = 1.5;
+
+    UltrasonicFrame frame {};
+    frame.range = 1.25;
+
+    const HakoCpp_Range pdu = IUltrasonicSensor::ToRangePdu(config, frame);
+
+    HAKO_TEST_EXPECT(pdu.header.frame_id == "ir_range", "unexpected infrared frame_id");
+    HAKO_TEST_EXPECT(pdu.radiation_type == 1, "unexpected infrared radiation type");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.field_of_view, 0.5F), "unexpected infrared field_of_view");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.min_range, 0.1F), "unexpected infrared min_range");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.max_range, 1.5F), "unexpected infrared max_range");
+    HAKO_TEST_EXPECT(NearlyEqual(pdu.range, 1.25F), "unexpected infrared range");
+}
+}
+
+int main()
+{
+    try {
+        TestRangePduConversion();
+        TestInfraredRadiationTypeConversion();
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "ultrasonic_range_pdu_converter_test passed" << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

This PR generalizes the existing camera-only sensor test flow into a shared sensor unit test flow.

Changes:

- Add shared `tests/sensors/support/sensor_test_utils.hpp`.
- Keep `tests/sensors/camera/support/camera_test_utils.hpp` as a camera-specific wrapper around the shared helpers.
- Rename the internal CMake helper from camera-specific to `hako_add_sensor_test`.
- Add ultrasonic unit tests:
  - `ultrasonic_config_loader_test`
  - `ultrasonic_range_pdu_converter_test`
- Add aggregate CMake targets:
  - `camera_unit_tests`
  - `ultrasonic_unit_tests`
  - `sensor_unit_tests`
  - `run_sensor_unit_tests`
- Update the existing sensor test workflow to build and run `sensor_unit_tests` instead of only camera tests.

## Notes

Smoke tests are intentionally left out of this PR. The ultrasonic interactive example already covers manual MuJoCo/viewer behavior, while this PR focuses on fast unit tests suitable for CI.

## Validation

Not run locally from this environment. The PR relies on GitHub Actions to validate the new CI path.